### PR TITLE
fix: 修复Pydantic版本兼容性问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ uvicorn>=0.23.2
 python-multipart>=0.0.6
 urllib3>=1.26.16
 jieba>=0.42.1
+pydantic>=2.9.2,<2.11.0
 
 # PDF处理相关
 


### PR DESCRIPTION
- 添加pydantic版本限制 (>=2.9.2,<2.11.0)
- 解决TypeError: argument of type 'bool' is not iterable错误
- 确保与gradio、fastapi等依赖库的兼容性
- 提升项目稳定性和运行可靠性

Fixes #issue报告的启动错误问题