### PR TITLE
[codex] Add Magick API model provider

### DIFF
--- a/api_router.py
+++ b/api_router.py
@@ -13,7 +13,7 @@ import asyncio
 from contextlib import asynccontextmanager
 
 # 从重构后的模块导入
-from config import SILICONFLOW_API_KEY
+from config import SILICONFLOW_API_KEY, MAGICK_API_KEY, is_configured_api_key
 from core.generator import query_answer
 from core.vector_store import vector_store
 from features.web_search import check_serpapi_key
@@ -43,7 +43,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="本地RAG API服务",
-    description="提供基于本地大模型和SERPAPI的文档问答API接口",
+    description="提供基于本地大模型、云端模型服务和SERPAPI的文档问答API接口",
     version="2.0.0",
     lifespan=lifespan
 )
@@ -131,7 +131,8 @@ async def ask_question(req: QuestionRequest):
 async def check_status():
     return {
         "status": "healthy",
-        "siliconflow_configured": bool(SILICONFLOW_API_KEY and not SILICONFLOW_API_KEY.startswith("Your")),
+        "siliconflow_configured": is_configured_api_key(SILICONFLOW_API_KEY),
+        "magick_configured": is_configured_api_key(MAGICK_API_KEY),
         "serpapi_configured": check_serpapi_key(),
         "vector_store_ready": vector_store.is_ready,
         "total_chunks": vector_store.total_chunks,

--- a/config.py
+++ b/config.py
@@ -34,14 +34,33 @@ SILICONFLOW_API_URL = os.getenv(
     "SILICONFLOW_API_URL",
     "https://api.siliconflow.cn/v1/chat/completions"
 )
+MAGICK_API_KEY = os.getenv("MAGICK_API_KEY")
+MAGICK_API_URL = os.getenv(
+    "MAGICK_API_URL",
+    "https://api.magickapi.com/v1/chat/completions"
+)
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # 第三步：模型名称配置
-# Ollama 格式: deepseek-r1:8b | SiliconFlow 格式: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+# Ollama 格式: deepseek-r1:8b
+# SiliconFlow/Magick API 格式: 使用对应平台提供的模型 ID
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 OLLAMA_MODEL_NAME = os.getenv("OLLAMA_MODEL_NAME", "deepseek-r1:8b")
 SILICONFLOW_MODEL_NAME = os.getenv("SILICONFLOW_MODEL_NAME", "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B")
+MAGICK_MODEL_NAME = os.getenv("MAGICK_MODEL_NAME", "gpt-4o-mini")
 RERANK_METHOD = os.getenv("RERANK_METHOD", "cross_encoder")
+
+MODEL_CHOICES = ["ollama", "siliconflow", "magick"]
+MODEL_DISPLAY_NAMES = {
+    "ollama": "本地 Ollama 模型",
+    "siliconflow": "Cloud DeepSeek-R1 模型",
+    "magick": "Magick API 模型"
+}
+
+
+def is_configured_api_key(api_key):
+    """判断 API Key 是否为用户实际配置值。"""
+    return bool(api_key and api_key.strip() and not api_key.strip().startswith("Your"))
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # 第四步：RAG 超参数
@@ -70,12 +89,17 @@ def detect_default_model():
 
     检测优先级：
     1. SiliconFlow API Key 已配置 → 默认使用云端 API
-    2. 本地 Ollama 服务可用 → 默认使用本地模型
-    3. 都不可用 → 返回 siliconflow 并提示用户配置
+    2. Magick API Key 已配置 → 默认使用 Magick API
+    3. 本地 Ollama 服务可用 → 默认使用本地模型
+    4. 都不可用 → 返回 siliconflow 并提示用户配置
     """
-    if SILICONFLOW_API_KEY and SILICONFLOW_API_KEY.strip() and not SILICONFLOW_API_KEY.startswith("Your"):
+    if is_configured_api_key(SILICONFLOW_API_KEY):
         logging.info("✅ 检测到 SiliconFlow API Key，默认使用云端模型")
         return "siliconflow"
+
+    if is_configured_api_key(MAGICK_API_KEY):
+        logging.info("✅ 检测到 Magick API Key，默认使用 Magick API 模型")
+        return "magick"
 
     try:
         response = requests.get("http://localhost:11434/api/tags", timeout=3)
@@ -85,7 +109,7 @@ def detect_default_model():
     except Exception:
         pass
 
-    logging.warning("⚠️ 未检测到可用 LLM 后端，请配置 SiliconFlow API Key 或启动 Ollama")
+    logging.warning("⚠️ 未检测到可用 LLM 后端，请配置 SiliconFlow/Magick API Key 或启动 Ollama")
     return "siliconflow"
 
 DEFAULT_MODEL_CHOICE = detect_default_model()

--- a/core/generator.py
+++ b/core/generator.py
@@ -1,10 +1,10 @@
 """
-LLM 调用 —— 大模型回答生成（Ollama + SiliconFlow）
+LLM 调用 —— 大模型回答生成（Ollama + SiliconFlow + Magick API）
 
 学习要点：
 - Prompt Engineering：如何构建高质量的提示词模板
 - 流式输出 vs 非流式输出的区别
-- 多模型适配：本地 Ollama 和云端 SiliconFlow API 的对接
+- 多模型适配：本地 Ollama、云端 SiliconFlow API 和 Magick API 的对接
 """
 
 import json
@@ -12,7 +12,8 @@ import logging
 import requests
 from config import (
     SILICONFLOW_API_KEY, SILICONFLOW_API_URL,
-    SILICONFLOW_MODEL_NAME, OLLAMA_MODEL_NAME
+    SILICONFLOW_MODEL_NAME, OLLAMA_MODEL_NAME,
+    MAGICK_API_KEY, MAGICK_API_URL, MAGICK_MODEL_NAME
 )
 from utils.network import get_session
 from core.retriever import recursive_retrieval
@@ -21,62 +22,140 @@ from features.conflict_detector import detect_conflicts, evaluate_source_credibi
 from features.thinking_chain import process_thinking_content
 
 
-def call_siliconflow_api(prompt, temperature=0.7, max_tokens=1024):
-    """调用 SiliconFlow 云端 API 获取回答"""
-    if not SILICONFLOW_API_KEY:
-        logging.error("未设置 SILICONFLOW_API_KEY")
-        return "错误：未配置 SiliconFlow API 密钥。"
+def _normalize_chat_completions_url(api_url):
+    """兼容用户填写 base URL 或完整 chat completions URL。"""
+    if not api_url:
+        return ""
+    url = api_url.strip().rstrip("/")
+    if url.endswith("/chat/completions"):
+        return url
+    return f"{url}/chat/completions"
 
+
+def _extract_openai_compatible_content(result):
+    """从 OpenAI-compatible 响应中提取回答文本和推理内容。"""
+    if "choices" not in result or not result["choices"]:
+        return "API返回结果格式异常"
+
+    message = result["choices"][0].get("message", {})
+    content = message.get("content", "")
+    reasoning = message.get("reasoning_content", "")
+
+    if isinstance(content, list):
+        content = "".join(
+            item.get("text", "") if isinstance(item, dict) else str(item)
+            for item in content
+        )
+
+    if reasoning:
+        return f"{content}<think>{reasoning}</think>"
+    return content
+
+
+def _call_openai_compatible_api(provider_name, api_key, api_url, model_name,
+                                prompt, temperature=0.7, max_tokens=1024,
+                                extra_payload=None):
+    """调用 OpenAI-compatible Chat Completions API 获取回答。"""
+    if not api_key:
+        logging.error(f"未设置 {provider_name} API Key")
+        return f"错误：未配置 {provider_name} API Key。"
+    if not api_url:
+        logging.error(f"未设置 {provider_name} API URL")
+        return f"错误：未配置 {provider_name} API URL。"
+
+    chat_url = _normalize_chat_completions_url(api_url)
     try:
         payload = {
-            "model": SILICONFLOW_MODEL_NAME,
+            "model": model_name,
             "messages": [{"role": "user", "content": prompt}],
-            "stream": False, "max_tokens": max_tokens,
-            "temperature": temperature, "top_p": 0.7, "top_k": 50,
-            "frequency_penalty": 0.5, "n": 1,
-            "response_format": {"type": "text"}
+            "stream": False,
+            "max_tokens": max_tokens,
+            "temperature": temperature
         }
+        if extra_payload:
+            payload.update(extra_payload)
         headers = {
-            "Authorization": f"Bearer {SILICONFLOW_API_KEY.strip()}",
+            "Authorization": f"Bearer {api_key.strip()}",
             "Content-Type": "application/json; charset=utf-8"
         }
         json_payload = json.dumps(payload, ensure_ascii=False).encode('utf-8')
-        response = requests.post(SILICONFLOW_API_URL, data=json_payload, headers=headers, timeout=180)
+        response = requests.post(chat_url, data=json_payload, headers=headers, timeout=180)
         response.raise_for_status()
         result = response.json()
+        return _extract_openai_compatible_content(result)
 
-        if "choices" in result and len(result["choices"]) > 0:
-            message = result["choices"][0]["message"]
-            content = message.get("content", "")
-            reasoning = message.get("reasoning_content", "")
-            if reasoning:
-                return f"{content}<think>{reasoning}</think>"
-            return content
-        return "API返回结果格式异常"
-
+    except requests.exceptions.HTTPError as e:
+        logging.error(f"调用{provider_name} API时出错: {str(e)}")
+        return (
+            f"调用{provider_name} API时出错: {str(e)}。"
+            f"请检查 API Key、API URL 和模型名称 {model_name} 是否可用。"
+        )
     except requests.exceptions.RequestException as e:
-        logging.error(f"调用SiliconFlow API时出错: {str(e)}")
-        return f"调用API时出错: {str(e)}"
+        logging.error(f"调用{provider_name} API时出错: {str(e)}")
+        return f"调用{provider_name} API时出错: {str(e)}"
     except Exception as e:
-        logging.error(f"SiliconFlow API 未知错误: {str(e)}")
+        logging.error(f"{provider_name} API 未知错误: {str(e)}")
         return f"发生未知错误: {str(e)}"
+
+
+def call_siliconflow_api(prompt, temperature=0.7, max_tokens=1024):
+    """调用 SiliconFlow 云端 API 获取回答"""
+    return _call_openai_compatible_api(
+        "SiliconFlow",
+        SILICONFLOW_API_KEY,
+        SILICONFLOW_API_URL,
+        SILICONFLOW_MODEL_NAME,
+        prompt,
+        temperature,
+        max_tokens,
+        extra_payload={
+            "top_p": 0.7,
+            "top_k": 50,
+            "frequency_penalty": 0.5,
+            "n": 1,
+            "response_format": {"type": "text"}
+        }
+    )
+
+
+def call_magick_api(prompt, temperature=0.7, max_tokens=1024):
+    """调用 Magick API 获取回答。"""
+    return _call_openai_compatible_api(
+        "Magick API",
+        MAGICK_API_KEY,
+        MAGICK_API_URL,
+        MAGICK_MODEL_NAME,
+        prompt,
+        temperature,
+        max_tokens
+    )
+
+
+def call_cloud_api(prompt, model_choice="siliconflow", temperature=0.7, max_tokens=1024):
+    """统一调用云端 OpenAI-compatible 模型服务。"""
+    if model_choice == "siliconflow":
+        return call_siliconflow_api(prompt, temperature, max_tokens)
+    if model_choice == "magick":
+        return call_magick_api(prompt, temperature, max_tokens)
+    raise ValueError(f"未知云端模型服务: {model_choice}")
 
 
 def call_llm_simple(prompt, model_choice="siliconflow"):
     """简单的 LLM 调用（用于递归检索中的查询改写判断）"""
-    if model_choice == "siliconflow":
-        result = call_siliconflow_api(prompt)
+    if model_choice in ("siliconflow", "magick"):
+        result = call_cloud_api(prompt, model_choice)
         result = result.strip() if isinstance(result, str) else result[0].strip()
         if "<think>" in result:
             result = result.split("<think>")[0].strip()
         return result
-    else:
+    elif model_choice == "ollama":
         response = get_session().post(
             "http://localhost:11434/api/generate",
             json={"model": OLLAMA_MODEL_NAME, "prompt": prompt, "stream": False},
             timeout=180
         )
         return response.json().get("response", "").strip()
+    raise ValueError(f"未知模型选择: {model_choice}")
 
 
 def _build_prompt(question, context, enable_web_search, knowledge_base_exists,
@@ -162,9 +241,9 @@ def query_answer(question, enable_web_search=False, model_choice="siliconflow", 
         if progress:
             progress(0.8, desc="生成回答...")
 
-        if model_choice == "siliconflow":
-            result = call_siliconflow_api(prompt, temperature=0.7, max_tokens=1536)
-        else:
+        if model_choice in ("siliconflow", "magick"):
+            result = call_cloud_api(prompt, model_choice, temperature=0.7, max_tokens=1536)
+        elif model_choice == "ollama":
             response = get_session().post(
                 "http://localhost:11434/api/generate",
                 json={"model": OLLAMA_MODEL_NAME, "prompt": prompt, "stream": False},
@@ -172,6 +251,8 @@ def query_answer(question, enable_web_search=False, model_choice="siliconflow", 
             )
             response.raise_for_status()
             result = str(response.json().get("response", "未获取到有效回答"))
+        else:
+            return f"错误：未知模型选择 {model_choice}"
 
         return process_thinking_content(result)
 
@@ -203,10 +284,10 @@ def stream_answer(question, enable_web_search=False, model_choice="siliconflow",
         prompt = _build_prompt(question, context, enable_web_search,
                                knowledge_base_exists, time_sensitive, conflict_detected)
 
-        if model_choice == "siliconflow":
-            full_answer = call_siliconflow_api(prompt, temperature=0.7, max_tokens=1536)
+        if model_choice in ("siliconflow", "magick"):
+            full_answer = call_cloud_api(prompt, model_choice, temperature=0.7, max_tokens=1536)
             yield process_thinking_content(full_answer), "完成!"
-        else:
+        elif model_choice == "ollama":
             response = get_session().post(
                 "http://localhost:11434/api/generate",
                 json={"model": OLLAMA_MODEL_NAME, "prompt": prompt, "stream": True},
@@ -223,6 +304,8 @@ def stream_answer(question, enable_web_search=False, model_choice="siliconflow",
                         yield full_answer, "生成回答中..."
 
             yield process_thinking_content(full_answer), "完成!"
+        else:
+            yield f"错误：未知模型选择 {model_choice}", "遇到错误"
 
     except Exception as e:
         yield f"系统错误: {str(e)}", "遇到错误"

--- a/example.env
+++ b/example.env
@@ -1,8 +1,12 @@
 SERPAPI_KEY=Your SERPAPI_KEY
 SILICONFLOW_API_KEY=
+MAGICK_API_KEY=
+MAGICK_API_URL=https://api.magickapi.com/v1/chat/completions
 
 # 模型名称配置（可选，不设置则使用默认值）
 # 本地 Ollama 模型名称
 # OLLAMA_MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
 # SiliconFlow 云端模型名称
 # SILICONFLOW_MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+# Magick API 模型名称
+# MAGICK_MODEL_NAME=gpt-4o-mini

--- a/rag_demo.py
+++ b/rag_demo.py
@@ -22,8 +22,9 @@ from datetime import datetime
 
 # 导入配置
 from config import (
-    DEFAULT_MODEL_CHOICE, SILICONFLOW_API_KEY,
-    OLLAMA_MODEL_NAME, SILICONFLOW_MODEL_NAME
+    DEFAULT_MODEL_CHOICE, SILICONFLOW_API_KEY, MAGICK_API_KEY,
+    OLLAMA_MODEL_NAME, SILICONFLOW_MODEL_NAME, MAGICK_MODEL_NAME,
+    MODEL_CHOICES, MODEL_DISPLAY_NAMES, is_configured_api_key
 )
 
 # 导入核心模块
@@ -32,7 +33,7 @@ from core.text_splitter import split_text
 from core.embeddings import encode_texts
 from core.vector_store import vector_store
 from core.bm25_index import bm25_manager
-from core.generator import query_answer, call_siliconflow_api
+from core.generator import query_answer, call_siliconflow_api, call_magick_api
 
 # 导入工具
 from utils.network import is_port_available
@@ -169,8 +170,14 @@ def get_system_models_info():
         "重排序模型": "交叉编码器 (distiluse-base-multilingual-cased-v2)",
         "生成模型(Ollama)": OLLAMA_MODEL_NAME,
         "生成模型(SiliconFlow)": SILICONFLOW_MODEL_NAME,
+        "生成模型(Magick API)": MAGICK_MODEL_NAME,
         "分词工具": "jieba (中文分词)"
     }
+
+
+def get_model_display_name(model_choice_val):
+    """返回 UI 中展示的模型服务名称。"""
+    return MODEL_DISPLAY_NAMES.get(model_choice_val, f"未知模型服务({model_choice_val})")
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -243,7 +250,7 @@ with gr.Blocks(title="本地RAG问答系统") as demo:
                                 info="打开后将同时搜索网络内容（需配置SERPAPI_KEY）"
                             )
                             model_choice = gr.Dropdown(
-                                choices=["ollama", "siliconflow"],
+                                choices=MODEL_CHOICES,
                                 value=DEFAULT_MODEL_CHOICE,
                                 label="模型选择", info="选择使用本地模型或云端模型"
                             )
@@ -338,7 +345,7 @@ with gr.Blocks(title="本地RAG问答系统") as demo:
             <p>2. <strong>模型选择</strong>：当前使用 <strong>%s</strong></p>
         </div>""" % (
             "已启用" if enable_web_search else "未启用",
-            "Cloud DeepSeek-R1 模型" if model_choice_val == "siliconflow" else "本地 Ollama 模型"
+            get_model_display_name(model_choice_val)
         )
 
         if not question or question.strip() == "":
@@ -363,7 +370,7 @@ with gr.Blocks(title="本地RAG问答系统") as demo:
             <p>2. <strong>模型选择</strong>：当前使用 <strong>%s</strong></p>
         </div>""" % (
             "已启用" if enable_web_search else "未启用",
-            "Cloud DeepSeek-R1 模型" if model_choice_val == "siliconflow" else "本地 Ollama 模型"
+            get_model_display_name(model_choice_val)
         )
 
     def get_system_metrics():
@@ -430,7 +437,7 @@ with gr.Blocks(title="本地RAG问答系统") as demo:
 
 def check_environment():
     """环境依赖检查"""
-    if SILICONFLOW_API_KEY and not SILICONFLOW_API_KEY.startswith("Your"):
+    if is_configured_api_key(SILICONFLOW_API_KEY):
         print("✅ SiliconFlow API 密钥已配置")
         try:
             result = call_siliconflow_api("你好，请回复'连接成功'", temperature=0.1, max_tokens=50)
@@ -442,19 +449,32 @@ def check_environment():
         except Exception as e:
             print(f"⚠️ SiliconFlow API 测试失败: {e}")
             return True
-    else:
-        print("⚠️ 未配置 SiliconFlow API 密钥，将尝试使用本地 Ollama")
+
+    if is_configured_api_key(MAGICK_API_KEY):
+        print("✅ Magick API 密钥已配置")
         try:
-            import requests
-            resp = requests.get("http://localhost:11434/api/tags", timeout=3)
-            if resp.status_code == 200:
-                print("✅ 本地 Ollama 服务可用")
-                return True
-        except Exception:
-            pass
-        print("❌ 未找到任何可用的 LLM 后端")
-        print("   请在 .env 中配置 SILICONFLOW_API_KEY 或启动 Ollama 服务")
-        return False
+            result = call_magick_api("你好，请回复'连接成功'", temperature=0.1, max_tokens=50)
+            if isinstance(result, str) and ("连接成功" in result or "你好" in result):
+                print("✅ Magick API 连接测试成功")
+            else:
+                print("⚠️ Magick API 响应异常，但继续运行")
+            return True
+        except Exception as e:
+            print(f"⚠️ Magick API 测试失败: {e}")
+            return True
+
+    print("⚠️ 未配置云端 API 密钥，将尝试使用本地 Ollama")
+    try:
+        import requests
+        resp = requests.get("http://localhost:11434/api/tags", timeout=3)
+        if resp.status_code == 200:
+            print("✅ 本地 Ollama 服务可用")
+            return True
+    except Exception:
+        pass
+    print("❌ 未找到任何可用的 LLM 后端")
+    print("   请在 .env 中配置 SILICONFLOW_API_KEY / MAGICK_API_KEY 或启动 Ollama 服务")
+    return False
 
 
 if __name__ == "__main__":

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 <img src="https://img.shields.io/badge/RAG-Document%20%2B%20网络%20(可选)-orange" alt="RAG类型">
 <img src="https://img.shields.io/badge/UI-Gradio-blueviolet" alt="界面">
 <img src="https://img.shields.io/badge/VectorStore-FAISS-yellow" alt="向量存储">
-<img src="https://img.shields.io/badge/LLM-Ollama%20%7C%20SiliconFlow-lightgrey" alt="LLM支持">
+<img src="https://img.shields.io/badge/LLM-Ollama%20%7C%20SiliconFlow%20%7C%20Magick%20API-lightgrey" alt="LLM支持">
 </p>
 </div>
 
@@ -17,7 +17,7 @@
 *   **拆解RAG黑盒**：亲手实现从文档加载、文本切分、向量化、检索到生成的完整链路
 *   **掌握关键技术选型**：体验FAISS向量检索与BM25关键词检索的混合策略
 *   **实践性能优化技巧**：通过交叉编码器重排序、递归检索等高级功能，学习提升RAG系统准确性
-*   **构建多模型适配能力**：集成本地Ollama与云端SiliconFlow API，掌握不同LLM引擎的对接策略
+*   **构建多模型适配能力**：集成本地Ollama、云端SiliconFlow API与Magick API，掌握不同LLM引擎的对接策略
 
 ## 🌟 核心功能
 
@@ -25,7 +25,7 @@
 *   🔍 **混合检索**：FAISS语义检索 + BM25关键词检索，提高检索召回率和准确性
 *   🔄 **结果重排序**：支持交叉编码器（CrossEncoder）和LLM对检索结果进行重排序
 *   🌐 **联网搜索增强 (可选)**：通过SerpAPI获取实时网络信息（需配置API密钥）
-*   🗣️ **本地/云端**：可选择使用本地Ollama大模型或云端SiliconFlow API进行推理
+*   🗣️ **本地/云端**：可选择使用本地Ollama大模型、云端SiliconFlow API或Magick API进行推理
 *   🤖 **智能回退**：启动时自动检测可用LLM后端，优先使用已配置的服务
 *   🖥️ **用户友好界面**：基于Gradio构建交互式Web界面
 *   📊 **分块可视化**：在UI上展示文档分块情况，帮助理解数据处理过程
@@ -125,9 +125,19 @@ graph TD
 
     # 编辑 .env 填入你的 API Key
     # 至少配置以下其中一项：
-    # - SILICONFLOW_API_KEY: 云端大模型（推荐，无需本地GPU）
+    # - SILICONFLOW_API_KEY: SiliconFlow 云端大模型（推荐，无需本地GPU）
+    # - MAGICK_API_KEY: Magick API 云端模型服务
     # - 本地启动 Ollama 服务（需下载模型）
     ```
+
+    如果使用 Magick API，可在 `.env` 中配置：
+    ```bash
+    MAGICK_API_KEY=你的 Magick API Key
+    MAGICK_API_URL=https://api.magickapi.com/v1/chat/completions
+    MAGICK_MODEL_NAME=gpt-4o-mini
+    ```
+
+    `MAGICK_API_URL` 支持填写完整的 `/chat/completions` 地址，也支持填写以 `/v1` 结尾的 OpenAI-compatible base URL。
 
 4.  **安装并启动Ollama服务** (可选，如果希望使用本地大模型):
     *   访问 [https://ollama.com/download](https://ollama.com/download) 下载并安装Ollama
@@ -141,8 +151,9 @@ graph TD
 | 优先级 | 条件 | 行为 |
 |--------|------|------|
 | 1 | `.env` 中配置了 `SILICONFLOW_API_KEY` | 默认使用云端 SiliconFlow API |
-| 2 | 本地 Ollama 服务可用 | 默认使用本地 Ollama 模型 |
-| 3 | 都不可用 | 提示用户配置 |
+| 2 | `.env` 中配置了 `MAGICK_API_KEY` | 默认使用 Magick API |
+| 3 | 本地 Ollama 服务可用 | 默认使用本地 Ollama 模型 |
+| 4 | 都不可用 | 提示用户配置 |
 
 > 在 UI 中你随时可以通过下拉框手动切换模型。
 


### PR DESCRIPTION
## Summary

Adds Magick API as an optional cloud model provider alongside Ollama and SiliconFlow.

## Changes

- Add `MAGICK_API_KEY`, `MAGICK_API_URL`, and `MAGICK_MODEL_NAME` configuration.
- Add a shared OpenAI-compatible chat completions caller used by SiliconFlow and Magick API.
- Add `magick` to the Gradio model selector and runtime environment checks.
- Expose Magick API configuration status from `/api/status`.
- Update `example.env` and `readme.md` with Magick API setup guidance.

## Validation

- `python3 -m compileall config.py core/generator.py rag_demo.py api_router.py`
- `git diff --check`

Closes #46
