### PR TITLE
Update CI actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.10"
           cache: pip


### PR DESCRIPTION
## Summary

Update GitHub-maintained Actions to their current v7 major releases so CI runs natively on Node.js 24 without deprecation annotations.

## Source

Verified against the latest official releases of `actions/checkout` and `actions/setup-python` on 2026-08-12.

## Validation

The workflow will run the same Python dependency install, source compilation, and 8-test suite on this pull request.